### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/CucumberTrainingTests/build.gradle
+++ b/CucumberTrainingTests/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1',
+    compile 'commons-collections:commons-collections:3.2.2',
 			'org.apache.commons:commons-lang3:3.1'	
     testCompile 'junit:junit:4.11',
 			'info.cukes:cucumber-java:1.1.6',

--- a/SeleniumTrainingTests/build.gradle
+++ b/SeleniumTrainingTests/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1',
+    compile 'commons-collections:commons-collections:3.2.2',
 			'org.apache.commons:commons-lang3:3.1'	
     testCompile 'org.seleniumhq.selenium:selenium-java:2.40.0',
 				'junit:junit:4.11'

--- a/StudentCucumberExercises/build.gradle
+++ b/StudentCucumberExercises/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1',
+    compile 'commons-collections:commons-collections:3.2.2',
 			'org.apache.commons:commons-lang3:3.1'	
     testCompile 'junit:junit:4.11',
 			'info.cukes:cucumber-java:1.1.6',

--- a/StudentFinalExercise/build.gradle
+++ b/StudentFinalExercise/build.gradle
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    compile 'commons-collections:commons-collections:3.2.1',
+    compile 'commons-collections:commons-collections:3.2.2',
 			'org.apache.commons:commons-lang3:3.1'	
     testCompile 'org.seleniumhq.selenium:selenium-java:2.40.0',
 				'junit:junit:4.11',


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
